### PR TITLE
selectable TOOLCHAIN

### DIFF
--- a/console/Makefile
+++ b/console/Makefile
@@ -1,6 +1,6 @@
 # Copyright 2014-2024 the IchigoJam authors. All rights reserved. MIT license.
 
-TOOLCHAIN=gcc
+TOOLCHAIN?=gcc
 include Makefile.$(TOOLCHAIN)
 
 all: IchigoJam_BASIC

--- a/console/README.md
+++ b/console/README.md
@@ -3,13 +3,19 @@
 ## setup
 
 - install gcc
-- install make
+- install GNU make
 
 ## build
 
 ```sh
 cd console
 make
+```
+
+you can select toolchain like this
+
+```
+make TOOLCHAIN=clang
 ```
 
 ## run


### PR DESCRIPTION
this enables
```
TOOLCHAIN=clang make
```
without modifying Makefile.

This is first aid, and I think it should be accept `CC=compiler make` style in the future.